### PR TITLE
add collectionName

### DIFF
--- a/src/MongoDb.php
+++ b/src/MongoDb.php
@@ -89,14 +89,15 @@ class MongoDb
      * @return array
      * @throws MongoDBException
      */
-    public function findOne($filter = [], array $options = [], array $collectionOptions = []): array
+    public function findOne($filter = [], array $options = [], array $collectionOptions = [], string $collectionName = ''): array
     {
         try {
             /**
              * @var $collection MongoDBConnection
              */
             $collection = $this->getConnection();
-            return $collection->findOne($this->collectionName, $filter, $options, $collectionOptions);
+            $collectionName = empty($this->collectionName) ? $collectionName : $this->collectionName;
+            return $collection->findOne($collectionName, $filter, $options, $collectionOptions);
         } catch (\Exception $e) {
             throw new MongoDBException($this->handleErrorMsg($e));
         }
@@ -109,17 +110,19 @@ class MongoDb
      * @param array  $filter
      * @param array  $options
      * @param array  $collectionOptions
+     * @param string $collectionName
      * @return array
      * @throws MongoDBException
      */
-    public function findAll(array $filter = [], array $options = [], array $collectionOptions = [])
+    public function findAll(array $filter = [], array $options = [], array $collectionOptions = [], string $collectionName = '')
     {
         try {
             /**
              * @var $collection MongoDBConnection
              */
             $collection = $this->getConnection();
-            return $collection->findAll($this->collectionName, $filter, $options, $collectionOptions);
+            $collectionName = empty($this->collectionName) ? $collectionName : $this->collectionName;
+            return $collection->findAll($collectionName, $filter, $options, $collectionOptions);
         } catch (\Exception $e) {
             throw new MongoDBException($this->handleErrorMsg($e));
         }
@@ -129,6 +132,7 @@ class MongoDb
      * 返回满足filer的分页数据
      *
      * @Task(timeout=30)
+     * @param string $collectionName
      * @param int    $currentPage
      * @param int    $limit
      * @param array  $filter
@@ -137,14 +141,14 @@ class MongoDb
      * @return array
      * @throws MongoDBException
      */
-    public function findPagination(int $currentPage, int $limit,  array $filter = [], array $options = [], array $collectionOptions = [])
+    public function findPagination(string $collectionName, int $currentPage, int $limit,  array $filter = [], array $options = [], array $collectionOptions = [])
     {
         try {
             /**
              * @var $collection MongoDBConnection
              */
             $collection = $this->getConnection();
-            return $collection->findPagination($this->collectionName, $currentPage, $limit,  $filter, $options, $collectionOptions);
+            return $collection->findPagination($collectionName, $currentPage, $limit,  $filter, $options, $collectionOptions);
         } catch (\Exception  $e) {
             throw new MongoDBException($this->handleErrorMsg($e));
         }
@@ -480,17 +484,19 @@ class MongoDb
      * @param array $pipeline
      * @param array $options
      * @param array $collectionOptions
+     * @param string $collectionName
      * @return \Traversable
      * @throws MongoDBException
      */
-    public function aggregate(array $pipeline = [], array $options = [], array $collectionOptions = [])
+    public function aggregate( array $pipeline = [], array $options = [], array $collectionOptions = [], string $collectionName = '')
     {
         try {
             /**
              * @var $collection MongoDBConnection
              */
             $collection = $this->getConnection();
-            return $collection->aggregate($this->collectionName, $pipeline, $options, $collectionOptions);
+            $collectionName = empty($this->collectionName) ? $collectionName : $this->collectionName;
+            return $collection->aggregate($collectionName, $pipeline, $options, $collectionOptions);
         } catch (\Exception $e) {
             throw new MongoDBException($this->handleErrorMsg($e));
         }


### PR DESCRIPTION
因为使用了注解@task  
所以会在启动的时候 在runtime里生成runtime/container/proxy/Phper666_MongoDb_MongoDb.proxy.php
```
public function findAll(array $filter = [], array $options = [], array $collectionOptions = [])
    {
        $__function__ = __FUNCTION__;
        $__method__ = __METHOD__;
        var_dump(1, $this->collectionName);
        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (array $filter = [], array $options = [], array $collectionOptions = []) use($__function__, $__method__) {
            try {
                var_dump(2, $this->collectionName);
                /**
                 * @var $collection MongoDBConnection
                 */
                $collection = $this->getConnection();
                return $collection->findAll($this->collectionName, $filter, $options, $collectionOptions);
            } catch (\Exception $e) {
                throw new MongoDBException($this->handleErrorMsg($e));
            }
        });
    }
```
__proxyCall 上面的部分 第一次执行是有值的。但是在__proxyCall再次调用本身的时候 $this->collectionName就没有值了。
这种情况只有在config/autoload/crontab.php 里调用的时候 才会出现。
如果直接在命令行执行，是直接调用的vendor里的MongoDb.php 这时候就不会发生。我也比较纳闷。

线上问题 希望可以合并，这样我就不用自己打包发布了。